### PR TITLE
Fix generation of release changelog

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Version (tag)'
+        description: 'New version/tag to generate'
         required: true
 
 jobs:
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ docker-push: docker-build
 	docker push ${VENDOR}/protobuf-tools
 
 release:
+	git fetch --all
 	RELEASE_MESSAGE=`scripts/release_message.sh` make release/post
 
 release/post:


### PR DESCRIPTION
ref. https://github.com/olxbr/protobuf-tools/pull/6

CI needs to fetch the history to be able to generate a changelog for the new version.